### PR TITLE
Use correct path when query string exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ typings/
 .history
 
 .vscode
+
+.idea

--- a/lib/helpers/response-adapter.js
+++ b/lib/helpers/response-adapter.js
@@ -27,19 +27,22 @@ function getRequestMethod(request) {
 }
 
 function getRequestPath(request) {
-  let path;
+  // request promise
+  if (request.uri) {
+    return request.uri.pathname;
+  }
 
-  // other
+  // axios
   if (request.path) {
-    ({ path } = request);
+    return request.path;
   }
 
   // supertest
   if (get(request, 'req.path')) {
-    ({ path } = request.req);
+    return request.req.path;
   }
 
-  return (path ? path.split('?')[0] : undefined);
+  return undefined;
 }
 
 function getResponseHeaders(response) {

--- a/lib/helpers/response-adapter.js
+++ b/lib/helpers/response-adapter.js
@@ -27,17 +27,19 @@ function getRequestMethod(request) {
 }
 
 function getRequestPath(request) {
+  let path;
+
   // other
   if (request.path) {
-    return request.path;
+    path = request.path;
   }
 
   // supertest
   if (get(request, 'req.path')) {
-    return request.req.path;
+    path = request.req.path;
   }
 
-  return undefined;
+  return (path ? path.split('?')[0] : undefined);
 }
 
 function getResponseHeaders(response) {

--- a/lib/helpers/response-adapter.js
+++ b/lib/helpers/response-adapter.js
@@ -31,12 +31,12 @@ function getRequestPath(request) {
 
   // other
   if (request.path) {
-    path = request.path;
+    ({ path } = request);
   }
 
   // supertest
   if (get(request, 'req.path')) {
-    path = request.req.path;
+    ({ path } = request.req);
   }
 
   return (path ? path.split('?')[0] : undefined);

--- a/test/helpers/response-generator.js
+++ b/test/helpers/response-generator.js
@@ -14,7 +14,7 @@ module.exports.request = (options = {}) => {
 
   return rp({
     method: options.method || defaults.method,
-    baseUrl: defaults.url,
+    baseUrl: options.url || defaults.url,
     uri: options.uri || options.path || defaults.path,
     resolveWithFullResponse: true,
     simple: options.simple,

--- a/test/response-adapter.test.js
+++ b/test/response-adapter.test.js
@@ -19,7 +19,7 @@ describe('responseAdapter', () => {
     expect(parseResponse(response)).to.be.like(expectedResponse);
   });
 
-  it('request-promise response with query string', async () => {
+  it('request-promise request with query string', async () => {
     const response = await request({
       status: 200,
       url: 'http://www.google.com/v2/pet/123?querty=value',
@@ -52,6 +52,17 @@ describe('responseAdapter', () => {
     expect(parseResponse(response)).to.be.like(expectedResponse);
   });
 
+  it('axios request with query string', async () => {
+    const response = await axios({
+      status: 200,
+      url: 'http://www.google.com/v2/pet/123?querty=value',
+      body: responses.body.valid.value,
+      headers: responses.headers.valid.value,
+    });
+
+    expect(parseResponse(response)).to.be.like(expectedResponse);
+  });
+
   it('axios non-2xx response', async () => {
     try {
       await axios({
@@ -68,6 +79,17 @@ describe('responseAdapter', () => {
   it('supertest response', async () => {
     const response = await supertest({
       status: 200,
+      body: responses.body.valid.value,
+      headers: responses.headers.valid.value,
+    });
+
+    expect(parseResponse(response)).to.be.like(expectedResponse);
+  });
+
+  it('supertest request with query string', async () => {
+    const response = await supertest({
+      status: 200,
+      url: 'http://www.google.com/v2/pet/123?querty=value',
       body: responses.body.valid.value,
       headers: responses.headers.valid.value,
     });

--- a/test/response-adapter.test.js
+++ b/test/response-adapter.test.js
@@ -19,6 +19,17 @@ describe('responseAdapter', () => {
     expect(parseResponse(response)).to.be.like(expectedResponse);
   });
 
+  it('request-promise response with query string', async () => {
+    const response = await request({
+      status: 200,
+      url: 'http://www.google.com/v2/pet/123?querty=value',
+      body: responses.body.valid.value,
+      headers: responses.headers.valid.value,
+    });
+
+    expect(parseResponse(response)).to.be.like(expectedResponse);
+  });
+
   it('request-promise non-2xx response', async () => {
     try {
       await request({


### PR DESCRIPTION
when path contains query string, do not consider it as part of path