### PR TITLE
Add support for overriding schema building options and tests for supporting non-standard content-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ Uncovered API definitions found:
 /v2/pet/:petId/uploadImage | POST       | 200         
 ```
 
+## Custom Content-Type support
+
+In case you are using non-standard Content-Type for your responses (e. g. when using Hypermedia), you can override Content-Type used by OpenAPI 3.0 validator for resolving response schema:
+
+```js
+use(matchApiSchema({
+    apiDefinitionsPath,
+    buildSchemaOptions: { responseContentType: 'application/hal+json'},
+    reportCoverage: true
+}));
+```
+
 ## Supported request libraries
 - supertest
 - axios

--- a/README.md
+++ b/README.md
@@ -131,18 +131,6 @@ Uncovered API definitions found:
 /v2/pet/:petId/uploadImage | POST       | 200         
 ```
 
-## Custom Content-Type support
-
-In case you are using non-standard Content-Type for your responses (e. g. when using Hypermedia), you can override Content-Type used by OpenAPI 3.0 validator for resolving response schema:
-
-```js
-use(matchApiSchema({
-    apiDefinitionsPath,
-    buildSchemaOptions: { responseContentType: 'application/hal+json'},
-    reportCoverage: true
-}));
-```
-
 ## Supported request libraries
 - supertest
 - axios

--- a/lib/helpers/ajv-utils.js
+++ b/lib/helpers/ajv-utils.js
@@ -8,6 +8,10 @@ module.exports.parseErrors = (errors, response) => ({
 
 function mapValuesByDataPath(errors, response) {
   return errors && errors.reduce((prev, error) => {
+    if (!error.dataPath) {
+      return prev;
+    }
+
     const { root, fullPath } = getDataPath(error.dataPath);
     const value = get(response, fullPath);
 
@@ -20,6 +24,10 @@ function mapValuesByDataPath(errors, response) {
 
 function mapErrorsByDataPath(errors) {
   return errors && errors.reduce((prev, error) => {
+    if (!error.params) {
+      return prev;
+    }
+
     const { missingProperty } = error.params;
     const { fullPath } = getDataPath(error.dataPath);
 

--- a/lib/helpers/coverage.js
+++ b/lib/helpers/coverage.js
@@ -8,9 +8,10 @@ const buildTable = require('./coverage-table');
 let coverage;
 let schema;
 
-module.exports.init = ({ reportCoverage, apiDefinitionsPath }) => {
+module.exports.init = ({ reportCoverage, apiDefinitionsPath, buildSchemaOptions }) => {
   coverage = {};
-  schema = schemaUtils.getSchema(apiDefinitionsPath);
+  const buildSchemaOptionsOverride = buildSchemaOptions || {};
+  schema = schemaUtils.getSchema(apiDefinitionsPath, buildSchemaOptionsOverride);
 
   if (reportCoverage === true) {
     process.on('beforeExit', () => {

--- a/lib/helpers/schema-utils.js
+++ b/lib/helpers/schema-utils.js
@@ -6,11 +6,14 @@ const base64 = require('./base64');
 module.exports.getSchema = (() => {
   const schemas = {};
 
-  return (filePath) => {
+  return (filePath, buildSchemaOptsOverrides) => {
     const encodedFilePath = base64.encode(filePath);
 
     if (!schemas[encodedFilePath]) {
-      schemas[encodedFilePath] = apiSchemaBuilder.buildSchemaSync(filePath, buildSchemaOpts);
+      schemas[encodedFilePath] = apiSchemaBuilder.buildSchemaSync(filePath, {
+        ...buildSchemaOpts,
+        ...buildSchemaOptsOverrides,
+      });
     }
     return schemas[encodedFilePath];
   };

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -7,12 +7,13 @@ const { setCoverage } = require('./helpers/coverage');
 
 module.exports.schemaValidator = function schemaValidator(obj, options = {}) {
   const { apiDefinitionsPath } = options;
+  const buildSchemaOptions = options.buildSchemaOptions || {};
 
   // load the schema
   if (!apiDefinitionsPath) {
     throw new Error(messages.REQUIRED_API_DEFINITIONS_PATH);
   }
-  const schema = schemaUtils.getSchema(apiDefinitionsPath);
+  const schema = schemaUtils.getSchema(apiDefinitionsPath, buildSchemaOptions);
 
   // parse the response object
   const parsedResponse = responseAdapter.parseResponse(obj);

--- a/package-lock.json
+++ b/package-lock.json
@@ -607,6 +607,7 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
       "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -651,15 +652,29 @@
       }
     },
     "api-schema-builder": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/api-schema-builder/-/api-schema-builder-1.1.0.tgz",
-      "integrity": "sha512-F2J82ep4izaMKyyBuEmZH0mhVJ6xCy/85B+k4J2q84iNbH+mCNWR+z64VAXAj9W1X6vIvw7mjfzu8tJt2C5Eow==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/api-schema-builder/-/api-schema-builder-1.1.2.tgz",
+      "integrity": "sha512-6W7PKfvMvCU5XCFP6ZqStcJrRmE5fWLJLDd9xPBC84v0JRURIMVDUOms5zvbavMFFytA5ogbJxLATTbY1G3Vfg==",
       "requires": {
-        "ajv": "^6.10.0",
+        "ajv": "^6.10.1",
         "clone-deep": "^4.0.1",
         "js-yaml": "^3.13.1",
-        "json-schema-deref-sync": "^0.10.0",
+        "json-schema-deref-sync": "^0.10.1",
+        "object.values": "^1.1.0",
         "swagger-parser": "^6.0.5"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
+          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        }
       }
     },
     "append-transform": {
@@ -1642,7 +1657,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -1904,7 +1918,6 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -1918,7 +1931,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -3288,8 +3300,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -3411,7 +3422,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -3441,8 +3451,7 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "has-value": {
       "version": "1.0.0",
@@ -3715,8 +3724,7 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -3750,8 +3758,7 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -3778,6 +3785,11 @@
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -3790,27 +3802,20 @@
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
     },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "requires": {
+        "is-extglob": "^1.0.0"
+      }
+    },
     "is-invalid-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
       "integrity": "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=",
       "requires": {
         "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
       }
     },
     "is-number": {
@@ -3851,7 +3856,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -3866,7 +3870,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -4685,18 +4688,25 @@
       "dev": true
     },
     "json-schema-deref-sync": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.10.0.tgz",
-      "integrity": "sha512-hnm4BhYarAo+e4yar/54DQ6ob0Q/GFihHEdX6gk47hs1qM3dfuHzcw487Kqz2jEVHjiiNSdZVSbWkPlrf/vc0Q==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.10.1.tgz",
+      "integrity": "sha512-ESkdgGyLg5H0el8VvLe3ss8ANsRH05dPOG19HQ2T4hWG/rD1N6Iei7Xltc8Wwcz4pqc+mGWihP2d4mFWtk7A3A==",
       "requires": {
         "clone": "^2.1.2",
         "dag-map": "~1.0.0",
         "is-valid-path": "^0.1.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "md5": "~2.2.0",
         "memory-cache": "~0.2.0",
         "traverse": "~0.6.6",
         "valid-url": "~1.0.9"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.14",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+        }
       }
     },
     "json-schema-ref-parser": {
@@ -5113,9 +5123,9 @@
       "dev": true
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -5545,8 +5555,7 @@
     "object-keys": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
-      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
-      "dev": true
+      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -5610,6 +5619,17 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
+      }
+    },
+    "object.values": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "once": {
@@ -6332,9 +6352,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -7265,38 +7285,15 @@
       }
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/Zooz/api-schema-validator#readme",
   "dependencies": {
-    "api-schema-builder": "kibertoad/api-schema-builder#feature/support-custom-content-type",
+    "api-schema-builder": "^1.1.2",
     "jest-diff": "^24.8.0",
     "jest-matcher-utils": "^24.8.0",
     "chalk": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/Zooz/api-schema-validator#readme",
   "dependencies": {
-    "api-schema-builder": "^1.1.0",
+    "api-schema-builder": "kibertoad/api-schema-builder#feature/support-custom-content-type",
     "chalk": "^2.4.2",
     "columnify": "^1.5.4",
     "lodash": "^4.17.11"

--- a/test/data/schema-custom-content-type.yaml
+++ b/test/data/schema-custom-content-type.yaml
@@ -1,0 +1,222 @@
+openapi: 3.0.0
+info:
+  description: "This is a sample server Petstore server.  You can find out more
+    about     Swagger at [http://swagger.io](http://swagger.io) or on
+    [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample,
+    you can use the api key `special-key` to test the
+    authorization     filters."
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+paths:
+  /v2/pet/{petId}:
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          headers:
+            X-Rate-Limit:
+              description: Request limit per hour.
+              schema:
+                type: integer
+                minimum: 0
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/xml:
+              schema:
+                type: object
+                required:
+                  - name
+                  - age
+                properties:
+                  name:
+                    type: string
+                    minLength: 4
+                  age:
+                    type: integer
+                    minimum: 0
+                    format: int32
+                  description:
+                    type: string
+            application/hal+json:
+              schema:
+                type: object
+                required:
+                  - name
+                  - age
+                properties:
+                  name:
+                    type: string
+                    minLength: 4
+                  age:
+                    type: integer
+                    minimum: 0
+                    format: int32
+                  description:
+                    type: string
+      security:
+        - api_key: []
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+servers:
+  - url: https://petstore.swagger.io/v2
+  - url: http://petstore.swagger.io/v2
+components:
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://petstore.swagger.io/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+        petId:
+          type: integer
+        quantity:
+          type: integer
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - placed
+            - approved
+            - delivered
+        complete:
+          type: boolean
+          default: false
+      xml:
+        name: Order
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+      xml:
+        name: Category
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+        phone:
+          type: string
+        userStatus:
+          type: integer
+          description: User Status
+      xml:
+        name: User
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+        category:
+          $ref: "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            $ref: "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+    ApiResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+        type:
+          type: string
+        message:
+          type: string

--- a/test/validation.test.js
+++ b/test/validation.test.js
@@ -33,16 +33,48 @@ describe('Schema validation', () => {
     const response = await request({
       status: 200,
       body: responses.body.valid.value,
-      headers: responses.headers.valid.value,
+      headers: {
+        ...responses.headers.valid.value,
+        'Content-Type': 'application/hal+json',
+      },
     });
 
-    expect(schemaValidator(response, { apiDefinitionsPath: apiDefinitionsPathCustomContentType, buildSchemaOptions: 'application/hal+json' })).to.be.like({
+    expect(schemaValidator(
+      response,
+      { apiDefinitionsPath: apiDefinitionsPathCustomContentType },
+    )).to.be.like({
       actual: null,
       errors: null,
       expected: null,
       matchMsg: 'expected response to match API schema',
       noMatchMsg: 'expected response to not match API schema',
       predicate: true,
+    });
+  });
+
+  it('Correctly returns error for undefined response', async () => {
+    const apiDefinitionsPathCustomContentType = path.join(__dirname, 'data', 'schema-custom-content-type.yaml');
+
+    const response = await request({
+      status: 200,
+      body: responses.body.valid.value,
+      headers: responses.headers.valid.value,
+    });
+
+    expect(schemaValidator(
+      response,
+      { apiDefinitionsPath: apiDefinitionsPathCustomContentType },
+    )).to.be.like({
+      actual: {},
+      errors: [
+        {
+          message: 'No schema defined for response content-type "application/json"',
+        },
+      ],
+      expected: {},
+      matchMsg: 'expected response to match API schema',
+      noMatchMsg: 'expected response to not match API schema',
+      predicate: false,
     });
   });
 

--- a/test/validation.test.js
+++ b/test/validation.test.js
@@ -27,6 +27,25 @@ describe('Schema validation', () => {
     });
   });
 
+  it('Response headers and body matches the schema with custom Content-Type', async () => {
+    const apiDefinitionsPathCustomContentType = path.join(__dirname, 'data', 'schema-custom-content-type.yaml');
+
+    const response = await request({
+      status: 200,
+      body: responses.body.valid.value,
+      headers: responses.headers.valid.value,
+    });
+
+    expect(schemaValidator(response, { apiDefinitionsPath: apiDefinitionsPathCustomContentType, buildSchemaOptions: 'application/hal+json' })).to.be.like({
+      actual: null,
+      errors: null,
+      expected: null,
+      matchMsg: 'expected response to match API schema',
+      noMatchMsg: 'expected response to not match API schema',
+      predicate: true,
+    });
+  });
+
   it('Response body does not match the schema', async () => {
     const response = await request({
       status: 200,


### PR DESCRIPTION
Depends on https://github.com/Zooz/api-schema-builder/pull/24 being merged first, feature-complete otherwise.